### PR TITLE
feature/responsive-schedule 1800 breakpoint

### DIFF
--- a/public/assets/css/dashboard-styles.css
+++ b/public/assets/css/dashboard-styles.css
@@ -54,6 +54,11 @@ main {
   animation: flyLeft 1s;
   z-index: 100;
 }
+@media only screen and (max-width: 1800px) {
+  .plant-grid {
+    grid-template-columns: 50% 50%;
+  }
+}
 
 @media only screen and (max-width: 1600px) {
   .plant-grid {


### PR DESCRIPTION
Updated the plant grid to have a breakpoint at 1800px and reduce the plant grid to 50% 50%.

`@media only screen and (max-width: 1800px) {
  .plant-grid {
    grid-template-columns: 50% 50%;
  }
}`